### PR TITLE
Fix Semgrep Security Rule: Prevent PostgreSQL Privilege Escalation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    security_opt:
+      - no-new-privileges:true
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary

This PR addresses a Semgrep security finding that identified a potential privilege escalation vulnerability in the PostgreSQL service configuration.

**Semgrep Rule**: Service 'postgres' allows for privilege escalation via setuid or setgid binaries

## Changes Made

- Added `no-new-privileges:true` in the `security_opt` section for the `postgres` service in `docker-compose.yml`
- This prevents the container from gaining new privileges through setuid or setgid binaries

## Security Impact

- ✅ Prevents privilege escalation attacks via setuid/setgid binaries
- ✅ Enhances container security posture
- ✅ Follows Docker security best practices
- ✅ No functional impact on application behavior

## Testing

The fix has been applied to the PostgreSQL service configuration and does not affect the application's functionality. The database service will continue to operate normally while being more secure.

## Files Modified

- `docker-compose.yml` - Added security option to postgres service (line 36-37)